### PR TITLE
gemspec: Explicit file list

### DIFF
--- a/base64.gemspec
+++ b/base64.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = ["README.md", "LICENSE.txt", "lib/base64.rb"]
   spec.bindir        = "exe"
   spec.executables   = []
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This avoids shelling out to git.