### PR TITLE
Improve Base64.urlsafe_encode64 performance

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -82,8 +82,14 @@ module Base64
   # You can remove the padding by setting +padding+ as false.
   def urlsafe_encode64(bin, padding: true)
     str = strict_encode64(bin)
+    unless padding
+      if str.end_with?("==")
+        str.delete_suffix!("==")
+      elsif str.end_with?("=")
+        str.chop!
+      end
+    end
     str.tr!("+/", "-_")
-    str.delete!("=") unless padding
     str
   end
 

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -82,13 +82,7 @@ module Base64
   # You can remove the padding by setting +padding+ as false.
   def urlsafe_encode64(bin, padding: true)
     str = strict_encode64(bin)
-    unless padding
-      if str.end_with?("==")
-        str.delete_suffix!("==")
-      elsif str.end_with?("=")
-        str.chop!
-      end
-    end
+    str.chomp!("==") or str.chomp!("=") unless padding
     str.tr!("+/", "-_")
     str
   end


### PR DESCRIPTION
Creating this here as asked in https://github.com/ruby/ruby/pull/4802

Improves the method's performance when asked to remove padding.

str.delete!("=") iterates over the entire string looking for the equals
character, but we know that we will, at most, find two at the end of the
string.