### PR TITLE
Avoid unnecessary string duplication in .urlsafe_decode64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "rake"
-gem "minitest"
+gem "test-unit"

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -99,9 +99,11 @@ module Base64
     # NOTE: RFC 4648 does say nothing about unpadded input, but says that
     # "the excess pad characters MAY also be ignored", so it is inferred that
     # unpadded input is also acceptable.
-    str = str.tr("-_", "+/")
     if !str.end_with?("=") && str.length % 4 != 0
       str = str.ljust((str.length + 3) & ~3, "=")
+      str.tr!("-_", "+/")
+    else
+      str = str.tr("-_", "+/")
     end
     strict_decode64(str)
   end


### PR DESCRIPTION
`String#ljust` returns a new string, so whenever we need to add padding, we can replace "-/" in place with `String#tr!` and avoid creating yet another copy of the string. My benchmarks point to a 1.08-1.18x speedup.

I took the time to replace minitest with test-unit as it's the testing framework being used. Probably just an old unnoticed detail.