### PR TITLE
Bump required_ruby_version to 2.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      min_version: 2.5
+      min_version: 2.4
   test:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})

--- a/base64.gemspec
+++ b/base64.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Support for encoding and decoding binary data using a Base64 representation.}
   spec.description   = %q{Support for encoding and decoding binary data using a Base64 representation.}
   spec.homepage      = "https://github.com/ruby/base64"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
The gem depends on String#unpack1, which was introduced in Ruby 2.4.