### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/base64

### DIFF
--- a/base64.gemspec
+++ b/base64.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 
   spec.files         = ["README.md", "LICENSE.txt", "lib/base64.rb"]
   spec.bindir        = "exe"


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/base64 which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/