### PR TITLE
Aliases for every method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ group :sig do
   gem "rbs"
   gem "rdoc", "<= 6.11"
 end
+gemspec

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -360,4 +360,13 @@ module Base64
     end
     strict_decode64(str)
   end
+
+  class << self
+    alias encode encode64
+    alias decode decode64
+    alias strict_encode strict_encode64
+    alias strict_decode strict_decode64
+    alias urlsafe_encode urlsafe_encode64
+    alias urlsafe_decode urlsafe_decode64
+  end
 end

--- a/test/base64/test_base64.rb
+++ b/test/base64/test_base64.rb
@@ -112,4 +112,13 @@ class TestBase64 < Test::Unit::TestCase
     assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
     assert_raise(ArgumentError) { Base64.urlsafe_decode64("AA=") }
   end
+
+  def test_aliases
+    assert_equal(Base64.method(:encode), Base64.method(:encode64))
+    assert_equal(Base64.method(:decode), Base64.method(:decode64))
+    assert_equal(Base64.method(:strict_encode), Base64.method(:strict_encode64))
+    assert_equal(Base64.method(:strict_decode), Base64.method(:strict_decode64))
+    assert_equal(Base64.method(:urlsafe_encode), Base64.method(:urlsafe_encode64))
+    assert_equal(Base64.method(:urlsafe_decode), Base64.method(:urlsafe_decode64))
+  end
 end


### PR DESCRIPTION
Basically, I hated how I had to write Base64.encode64, it felt so redundant, so I created aliases for every method of this library, to allow for a more simple "Base64.encode"

I also added tests for what I wrote, and "gemspec" to Gemfile to allow bin/console to load the gem you are working on, and not the one installed in the system