### PR TITLE
Remove new line character from strict_encode64 example

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -258,13 +258,13 @@ module Base64
   # <tt>+</tt> or <tt>/</tt>;
   # see {Encoding Character Set}[Base64.html#module-Base64-label-Encoding+Character+Sets] above:
   #
-  #   Base64.strict_encode64("\xFB\xEF\xBE") # => "++++\n"
-  #   Base64.strict_encode64("\xFF\xFF\xFF") # => "////\n"
+  #   Base64.strict_encode64("\xFB\xEF\xBE") # => "++++"
+  #   Base64.strict_encode64("\xFF\xFF\xFF") # => "////"
   #
   # The returned string may include padding;
   # see {Padding}[Base64.html#module-Base64-label-Padding] above.
   #
-  #   Base64.strict_encode64('*') # => "Kg==\n"
+  #   Base64.strict_encode64('*') # => "Kg=="
   #
   # The returned string will have no newline characters, regardless of its length;
   # see {Newlines}[Base64.html#module-Base64-label-Newlines] above:


### PR DESCRIPTION
<img width="582" height="229" alt="Screenshot 2025-09-19 at 7 27 37 PM" src="https://github.com/user-attachments/assets/c56c9d7d-0adc-453b-bb48-9844c09cdd86" />

From the doc: 

<img width="633" height="91" alt="Screenshot 2025-09-19 at 7 31 47 PM" src="https://github.com/user-attachments/assets/b1510530-fa87-4ce1-a401-0b1bc0d73fea" />
