### PR TITLE
Fix rbs:annotate task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem "test-unit"
 
 group :sig do
   gem "rbs"
-  gem "rdoc", "<= 6.11"
+  gem "rdoc"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,8 @@ namespace :rbs do
     require "pathname"
 
     Dir.mktmpdir do |tmpdir|
-      system("rdoc --ri --output #{tmpdir}/doc --root=. lib")
-      system("rbs annotate --no-system --no-gems --no-site --no-home -d #{tmpdir}/doc sig")
+      sh("rdoc --ri --output #{tmpdir}/doc --root=. lib")
+      sh("rbs annotate --no-system --no-gems --no-site --no-home -d #{tmpdir}/doc sig")
     end
   end
 


### PR DESCRIPTION
It is likely that the CI is currently failing.

```
bundle exec rake rbs:annotate
...snip...
/Users/ksss/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-6.11.0/lib/rdoc/store.rb:269:in 'File.join': no implicit conversion of RDoc::Options into String (TypeError)

    File.join @path, 'cache.ri'
              ^^^^^^^^^^^^^^^^^
```

This is because rbs v3.10 does not support rdoc < v6.16.
Also, rdoc v7 has been released, but the current Gemfile does not allow tasks to be executed with v7.

We should remove the restrictions on the Gemfile and fix it so that the tasks succeed.